### PR TITLE
RMX2151: sepolicy: Make gmscore_app permissive

### DIFF
--- a/sepolicy/private/gmscore_app.te
+++ b/sepolicy/private/gmscore_app.te
@@ -1,0 +1,1 @@
+permissive gmscore_app;


### PR DESCRIPTION
* I have tried addressing all denails for gmscore_app, still its causing weird issues on roms which come with prebuilt gapps like crashing upon setup * So, to fix this, for the time being, make gmscore_app permissive, might change it in future